### PR TITLE
[FIX][BUG] Updates react-type package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@types/node": "20.4.2",
-    "@types/react": "18.2.15",
+    "@types/react": "18.2.45",
     "@types/react-dom": "18.2.7",
     "boring-avatars": "^1.10.1",
     "classnames": "^2.3.2",


### PR DESCRIPTION
### Changes
- [x] Bumps react-type to its latest version

### Bug
`FocusLock` is having a TS error making a build to fail. The only fix is to bump up the `@types/react` package